### PR TITLE
remove horizontal scrolling on main viewport

### DIFF
--- a/src/partials/general.scss
+++ b/src/partials/general.scss
@@ -10,6 +10,7 @@ body{
 html, body{
   width:100%;
   height:100%;
+  overflow-x: hidden;
 }
 
 ol, ul{


### PR DESCRIPTION
Thought I was working in my own fork and merged a bit too quickly, wanted to run this by you guys first:

This will disable horizontal scrolling for the `html` and `body` elements so that the navigation menu is always visible in the top left corner.